### PR TITLE
Hacking in dox support for Coffeescript (and probably other langs with #-esque comment delims)

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -300,8 +300,15 @@ Docker.prototype.parseSections = function(data, filename){
           // extract any **jsDoc** parameters that are present.
           inMultiLineComment = false;
           if(params.dox){
-            multiLine += line + '\n';
+            multiLine += line;
             try{
+              // standardize the comment block delimiters to the only ones that
+              // dox seems to understand, namely, /* and */
+              multiLine = multiLine
+                .replace(params.multiLine[0], "/**")
+                .replace(params.multiLine[1], "*/")
+                .replace(/\n(\s*)/g, "\n$1* ");
+
               doxData = dox.parseComments(multiLine, {raw: true})[0];
               // Don't let dox do any markdown parsing. We'll do that all ourselves with md above
               doxData.md = md;
@@ -336,7 +343,7 @@ Docker.prototype.parseSections = function(data, filename){
           section = { docs: '', code: '' };
         }
         inMultiLineComment = true;
-        multiLine = line;
+        multiLine = line + "\n";
         continue;
       }
     }
@@ -378,7 +385,7 @@ Docker.prototype.languageParams = function(filename){
     case '.js':
       return { name: 'javascript',   comment: '//', multiLine: [ /\/\*/, /\*\// ], commentsIgnore: /^\s*\/\/=/, dox: true };
     case '.coffee':
-      return { name: 'coffeescript', comment: '#',  multiLine: [ /^#{3}$/, /^#{3}$/ ] };
+      return { name: 'coffeescript', comment: '#',  multiLine: [ /^\s*#{3}/, /#{3}/ ], dox: true };
     case '.rb':
       return { name: 'ruby',         comment: '#',  multiLine: [ /\=begin/, /\=end/ ] };
     case '.py':


### PR DESCRIPTION
Now you can do:

``` coffee
### 
  @param: {Array} wangsta gangsta
  @return: {String} blah blah blah
###
someFunc: (wangsta) =>
  ...
```

... and the `@param` and `@return` tags actually do what they're supposed to (and I suppose the same goes for whatever other `jsDoc` tags `dox` supports).
