### PR TITLE
Added styl, jade, groovy and gsp support

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -907,7 +907,7 @@ Docker.prototype.languages = {
     multiLine: [ /<%--/, /--%>/ ],
     pygment: "html"// .gsp is grails server pages in pygments, html is close enough.
   },
-  sass: {
+  styl: {
     extensions: [ 'styl' ], // .styl isn't supported by pygments, sass is close enough.
     comment: '//', multiLine: [ /\/\*/, /\*\// ],
     pygment: "sass"// .styl isn't supported by pygments, sass is close enough.


### PR DESCRIPTION
I love the docker project and used it to generate some docks on our projects.  We use groovy, gsps, jade, and stylus so I modified docker to work with them.

Jade definitely has some issues, and I had to introduce a pygment: element because pygments does not know what .styl files are (its similar to sass in formatting).

Cool project!
-Mikkel
