### PR TITLE
init sidebar before images are loaded (if supported)

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -210,7 +210,13 @@ function switchTab(tab){
  *
  * When the document is ready, make the sidebar and all that jazz
  */
-window.onload = function(){
+(function (init) {
+  if (window.addEventListener) {
+    window.addEventListener('DOMContentLoaded', init);
+  } else { // IE8 and below
+    window.onload = init;
+  }
+}(function(){
   makeTree(tree, relativeDir, thisFile);
   wireUpTabs();
 
@@ -220,4 +226,5 @@ window.onload = function(){
   }else{
     switchTab('tree');
   }
-};
+}));
+


### PR DESCRIPTION
The sidebar is currently initialized after all images are loaded, which can lead to a temporary absence of the sidebar if some images are loading slowly from an external server (like badges).
This patch initializes the sidebar directly after the DOM is loaded.
