### PR TITLE
Add support for LiveScript files

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -819,6 +819,11 @@ Docker.prototype.languages = {
     executables: [ 'coffee' ],
     comment: '#',  multiLine: [ /^\s*#{3}\s*$/m, /^\s*#{3}\s*$/m ], jsDoc: true
   },
+  livescript: {
+    extensions: [ 'ls' ],
+    executables: [ 'lsc' ],
+    comment: '#',  multiLine: [ /\/\*\*?/, /\*\// ], jsDoc: true
+  },
   ruby: {
     extensions: [ 'rb', 'rbw', 'rake', 'gemspec' ],
     executables: [ 'ruby' ],


### PR DESCRIPTION
Single-line comments are from CoffeeScript and multiline are from JavaScript.
