### PR TITLE
Added default handling for tags

### DIFF
--- a/res/jsDoc.jst
+++ b/res/jsDoc.jst
@@ -71,6 +71,21 @@ if(tags.length){
     </span>
 <%  }
 
+    if(tag.type == 'unknown'){                                      %>
+    <div class="dox_tag_title"><%= tag.name %></div>
+    <div class="dox_tag_detail">
+<%    if(tag.types){
+        for(var j = 0; j < tag.types.length; j += 1){           %>
+      <span class="dox_type"><%= tag.types[j] %></span>
+<%      }
+      }
+
+      if(tag.description){                                      %>
+      <span><%= md(tag.description, true) %></span>
+<%    }                                                         %>
+    </div>
+<%  }
+
     if(tag.type == 'see'){                                      %>
     <div class="dox_tag_title">See</div>
     <div class="dox_tag_detail">

--- a/src/docker.js
+++ b/src/docker.js
@@ -689,6 +689,11 @@ Docker.prototype.parseMultiline = function(comment){
             tag.local = bits.join(' ');
           }
           break;
+        default:
+          if(bits[0].charAt(0) == '{') tag.types = grabType(bits).split(/ *[|,\/] */);
+          tag.description = bits.join(' ');
+          tag.name = tagType;
+          tag.type = 'unknown';
       }
 
       return tag;


### PR DESCRIPTION
#62 is very simple, just adding support for aliases for existing functionality so that `@returns` behaves the same as `@return` etc.

This PR is a little bit bolder, and I've only done rudimentary testing with it, but it treats any tag it doesn't recognise in a similar way to `param` or `return` accepting a type and a description, and using the tag as the name so you get something like:

`@typedef {String} I am a description`

**typedef**
  _String_ I am a description

closes #45
