### PR TITLE
Fixes the error when adding external js files.

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -1269,6 +1269,10 @@ Docker.prototype.renderCodeHtml = function(sections, filename, cb){
     title: path.basename(filename),
     sections: sections
   });
+  function getBasename(_path){
+      return path.basename(_path);
+  }
+
   var html = this.renderTemplate({
     title: path.basename(filename),
     relativeDir: relDir,
@@ -1277,8 +1281,8 @@ Docker.prototype.renderCodeHtml = function(sections, filename, cb){
     sidebar: this.sidebarState,
     colourScheme: this.colourScheme,
     filename: filename.replace(this.inDir,'').replace(/^[\/\\]/,''),
-    js: this.extraJS.map(path.basename),
-    css: this.extraCSS.map(path.basename)
+    js: this.extraJS.map(getBasename),
+    css: this.extraCSS.map(getBasename)
   });
 
   var self = this;


### PR DESCRIPTION
Fixes this error:

```
❯ docker -o ../doc/ -i ./ --sidebar true --watch --js ../dist/externalLib.js

path.js:554
    throw new TypeError('ext must be a string');
          ^
TypeError: ext must be a string
    at posix.basename (path.js:554:11)
    at Array.map (native)
    at Docker.renderCodeHtml (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1283:22)
    at /Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:408:18
    at next (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1086:37)
    at /Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1093:7
    at next (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1151:39)
    at Docker.highlighExtractedCode (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1165:3)
    at Docker.extractDocCode (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1129:8)
    at next (/Users/nicolasb/.nvm/versions/io.js/v2.2.1/lib/node_modules/docker/src/docker.js:1090:10)
```