### PR TITLE
Display @typedef and @returns JSDoc comments.

### DIFF
--- a/res/jsDoc.ejs
+++ b/res/jsDoc.ejs
@@ -10,7 +10,9 @@
 
 if(tags.length){
   var hasParams = false, hasReturn = false, hasType = false, 
-  hasTypedef = false, hasProperties = false;                    -%>
+  hasTypedef = false, typedefName = null,  
+  hasProperties = false;                                        -%>
+
 <div class="details">
 <%
   tags.forEach(function(tag){
@@ -31,15 +33,16 @@ if(tags.length){
 </div>
 <%  }
 
-    if(tag.type == 'typedef'){
-      if(!hasTypedef){
-        hasTypedef = true;                                       -%>
-<div class="dox_tag_title">Type Definition</div>
-<%    }                                                         -%>
+    if(tag.type == 'typedef'){                                  -%>
+<div class="dox_tag_title">Type Definition</div>  
 <div class="dox_tag_detail">
-<span class="dox_tag_name"><%= tag.string %></span>
+<%    typedefName = tag.string.replace(/\{([^\}]*)\}/g, "");    -%>
+<span class="dox_tag_name"><%= typedefName %></span>
+<%    (tag.types || []).forEach(function(type){                 -%>
+<span class="dox_type"><%= type %></span>
+<%    });
 
-<%    if(tag.description){                                      -%>
+      if(tag.description){                                      -%>
 <span><%- md(tag.description, true) %></span>
 <%    }                                                         -%>
 </div>

--- a/res/jsDoc.ejs
+++ b/res/jsDoc.ejs
@@ -9,7 +9,8 @@
 <%
 
 if(tags.length){
-  var hasParams = false, hasReturn = false, hasType = false;    -%>
+  var hasParams = false, hasReturn = false, hasType = false, 
+  hasTypedef = false, hasProperties = false;                    -%>
 <div class="details">
 <%
   tags.forEach(function(tag){
@@ -30,7 +31,38 @@ if(tags.length){
 </div>
 <%  }
 
-    if(tag.type == 'return'){
+    if(tag.type == 'typedef'){
+      if(!hasTypedef){
+        hasTypedef = true;                                       -%>
+<div class="dox_tag_title">Type Definition</div>
+<%    }                                                         -%>
+<div class="dox_tag_detail">
+<span class="dox_tag_name"><%= tag.string %></span>
+
+<%    if(tag.description){                                      -%>
+<span><%- md(tag.description, true) %></span>
+<%    }                                                         -%>
+</div>
+<%  }
+
+    if(tag.type == 'property'){
+      if(!hasProperties){
+        hasProperties = true;                                   -%>
+<div class="dox_tag_title">Properties</div>
+<%    }                                                         -%>
+<div class="dox_tag_detail">
+<span class="dox_tag_name"><%= tag.name %></span>
+<%    (tag.types || []).forEach(function(type){                 -%>
+<span class="dox_type"><%= type %></span>
+<%    });
+
+      if(tag.description){                                      -%>
+<span><%- md(tag.description, true) %></span>
+<%    }                                                         -%>
+</div>
+<%  }
+
+    if(tag.type == 'return' || tag.type == 'returns'){
       if(!hasReturn){
         hasReturn = true;                                       -%>
 <div class="dox_tag_title">Returns</div>


### PR DESCRIPTION
When I tried running @typedef JSDoc comments through Docker, it would just display as an empty div. So I added @typedef support to the template file.

Also added @returns support since it's analogous with @return.